### PR TITLE
Add WebkitJSI patch settings toggle

### DIFF
--- a/Palladium/Resources/Localizable.xcstrings
+++ b/Palladium/Resources/Localizable.xcstrings
@@ -2447,6 +2447,46 @@
         }
       }
     },
+    "settings.advanced.disable_webkit_jsi_patch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable WebKit JSI patch"
+          }
+        }
+      }
+    },
+    "settings.advanced.disable_webkit_jsi_patch.help" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prevents Palladium from modifying the yt-dlp-apple-webkit-jsi runtime after installation or update."
+          }
+        }
+      }
+    },
+    "settings.advanced.subtitle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runtime compatibility controls"
+          }
+        }
+      }
+    },
+    "settings.advanced.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Advanced"
+          }
+        }
+      }
+    },
     "settings.after_download.subtitle" : {
       "localizations" : {
         "en" : {

--- a/Palladium/Resources/Localizable.xcstrings
+++ b/Palladium/Resources/Localizable.xcstrings
@@ -2507,6 +2507,16 @@
         }
       }
     },
+    "settings.advanced.restart_required" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restart Palladium to apply the WebKit JSI patch setting safely."
+          }
+        }
+      }
+    },
     "settings.advanced.title" : {
       "localizations" : {
         "en" : {

--- a/Palladium/Resources/Localizable.xcstrings
+++ b/Palladium/Resources/Localizable.xcstrings
@@ -2477,6 +2477,36 @@
         }
       }
     },
+    "settings.advanced.reinstall" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstall packages"
+          }
+        }
+      }
+    },
+    "settings.advanced.reinstall_prompt.message" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstall yt-dlp and WebKit JSI now so the installed runtime uses this setting."
+          }
+        }
+      }
+    },
+    "settings.advanced.reinstall_prompt.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstall packages?"
+          }
+        }
+      }
+    },
     "settings.advanced.title" : {
       "localizations" : {
         "en" : {

--- a/Palladium/Services/Python/PythonFlowRunner.swift
+++ b/Palladium/Services/Python/PythonFlowRunner.swift
@@ -181,7 +181,8 @@ enum PythonFlowRunner {
                 ytDlpExitCode: nil,
                 updatesAvailable: nil,
                 updatesSummary: nil,
-                availableVersions: nil
+                availableVersions: nil,
+                restartRequired: false
             )
         }
 
@@ -218,7 +219,8 @@ enum PythonFlowRunner {
             ytDlpExitCode: ytExitCode,
             updatesAvailable: nil,
             updatesSummary: nil,
-            availableVersions: nil
+            availableVersions: nil,
+            restartRequired: false
         )
     }
 
@@ -243,7 +245,8 @@ enum PythonFlowRunner {
                 ytDlpExitCode: nil,
                 updatesAvailable: nil,
                 updatesSummary: nil,
-                availableVersions: nil
+                availableVersions: nil,
+                restartRequired: false
             )
         }
 
@@ -253,6 +256,7 @@ enum PythonFlowRunner {
         let cancelled = result["cancelled"] as? Bool ?? false
         let updatesAvailable = result["updates_available"] as? Bool ?? false
         let updatesSummary = result["updates_summary"] as? String ?? "Not checked yet."
+        let restartRequired = result["restart_required"] as? Bool ?? false
         let output = result["output"] as? String ?? ""
         let versions = normalizedVersions(from: result["versions"])
         let availableVersions = normalizedAvailableVersions(from: result["available_versions"])
@@ -290,7 +294,8 @@ enum PythonFlowRunner {
             ytDlpExitCode: nil,
             updatesAvailable: updatesAvailable,
             updatesSummary: updatesSummary,
-            availableVersions: availableVersions
+            availableVersions: availableVersions,
+            restartRequired: restartRequired
         )
     }
 
@@ -400,6 +405,7 @@ struct PythonFlowOutcome: Sendable {
     let updatesAvailable: Bool?
     let updatesSummary: String?
     let availableVersions: [String: [String]]?
+    let restartRequired: Bool
 }
 
 struct PlaylistProgressSnapshot: Sendable {

--- a/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
+++ b/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
@@ -545,7 +545,7 @@ def run_yt_dlp_flow(
                 )
 
             if package_source.get("skip_webkit_patch"):
-                print("[palladium] skipping webkit patch for custom package source")
+                print("[palladium] skipping webkit patch by configuration")
             else:
                 raise_if_cancel_requested(cancel_file_path, "[palladium] cancellation requested before webkit patch")
                 ensure_safe_webkit_jsi_runtime(install_target)
@@ -885,7 +885,7 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
                 print(f"[palladium] post-update updates summary: {updates_summary}")
 
             if package_source.get("skip_webkit_patch"):
-                print("[palladium] skipping webkit patch for custom package source")
+                print("[palladium] skipping webkit patch by configuration")
             else:
                 raise_if_cancel_requested(cancel_file_path, "[palladium] package action cancelled before webkit patch")
                 ensure_safe_webkit_jsi_runtime(install_target)

--- a/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
+++ b/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
@@ -41,6 +41,14 @@ PLAYLIST_PROGRESS_PREFIX = "[palladium][playlist-progress] "
 
 def invalidate_runtime_package_modules():
     prefixes = ("yt_dlp", "yt_dlp_plugins")
+    webkit_jsi_loaded = any(
+        name == "yt_dlp_plugins.webkit_jsi" or name.startswith("yt_dlp_plugins.webkit_jsi.")
+        for name in sys.modules
+    )
+    if webkit_jsi_loaded:
+        print("[palladium] restart required to refresh loaded webkit jsi runtime")
+        return True
+
     stale_modules = [
         name
         for name in sys.modules
@@ -52,6 +60,7 @@ def invalidate_runtime_package_modules():
 
     importlib.invalidate_caches()
     print(f"[palladium] invalidated {len(stale_modules)} cached yt-dlp runtime module(s)")
+    return False
 
 
 class PlaylistProgressCollector:
@@ -794,6 +803,7 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
     available_versions = {}
     versions = {}
     cancelled = False
+    restart_required = False
     install_target = os.environ.get("PALLADIUM_PYTHON_PACKAGES")
     cancel_file_path = os.environ.get("PALLADIUM_CANCEL_FILE", "").strip()
     live_log_stream = open_live_log_stream(live_log_fd_override)
@@ -883,7 +893,7 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
                                 pip_exit_code = 0
                             else:
                                 pip_attempted = True
-                                invalidate_runtime_package_modules()
+                                restart_required = invalidate_runtime_package_modules() or restart_required
                                 if install_target:
                                     stale_removed = 0
                                     for package_name in cleanup_packages:
@@ -942,5 +952,6 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
         "updates_summary": updates_summary,
         "versions": versions,
         "available_versions": available_versions,
+        "restart_required": restart_required,
         "output": output.getvalue(),
     })

--- a/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
+++ b/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
@@ -830,8 +830,14 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
             if custom_versions:
                 print(f"[palladium] custom package versions requested: {custom_versions}")
 
-            if action == "update":
-                if updates_available or bool(custom_versions) or package_source.get("mode") == "custom":
+            if action in ("update", "reinstall"):
+                should_install = (
+                    action == "reinstall"
+                    or updates_available
+                    or bool(custom_versions)
+                    or package_source.get("mode") == "custom"
+                )
+                if should_install:
                     raise_if_cancel_requested(cancel_file_path, "[palladium] package action cancelled before pip startup")
                     pip_main = ensure_pip_entrypoint(install_target)
                     if pip_main is not None:
@@ -842,12 +848,19 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
                                 pip_main=pip_main,
                                 allow_prereleases=bool(package_source.get("allow_prereleases")),
                             )
-                            packages, cleanup_packages = build_package_install_plan(
-                                installed_versions,
-                                indexed_versions,
-                                custom_versions=custom_versions,
-                                package_source=package_source,
-                            )
+                            if action == "reinstall":
+                                if package_source.get("mode") == "custom":
+                                    packages = list(package_source.get("custom_specs") or [])
+                                else:
+                                    packages = ["yt-dlp", "yt-dlp-apple-webkit-jsi"]
+                                cleanup_packages = ["yt-dlp", "yt-dlp-apple-webkit-jsi"]
+                            else:
+                                packages, cleanup_packages = build_package_install_plan(
+                                    installed_versions,
+                                    indexed_versions,
+                                    custom_versions=custom_versions,
+                                    package_source=package_source,
+                                )
 
                             if not packages:
                                 print("[palladium] no package installs required")

--- a/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
+++ b/Palladium/Services/Python/palladium_ytdlp/entrypoints.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib
 import json
 import os
 import re
@@ -36,6 +37,21 @@ from .shared import TRACKED_PACKAGES, TailBuffer, Tee, open_live_log_stream
 from .webkit_jsi import ensure_safe_webkit_jsi_runtime
 
 PLAYLIST_PROGRESS_PREFIX = "[palladium][playlist-progress] "
+
+
+def invalidate_runtime_package_modules():
+    prefixes = ("yt_dlp", "yt_dlp_plugins")
+    stale_modules = [
+        name
+        for name in sys.modules
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+    ]
+
+    for name in stale_modules:
+        sys.modules.pop(name, None)
+
+    importlib.invalidate_caches()
+    print(f"[palladium] invalidated {len(stale_modules)} cached yt-dlp runtime module(s)")
 
 
 class PlaylistProgressCollector:
@@ -867,6 +883,7 @@ def run_package_maintenance(action, custom_versions_json=None, live_log_fd_overr
                                 pip_exit_code = 0
                             else:
                                 pip_attempted = True
+                                invalidate_runtime_package_modules()
                                 if install_target:
                                     stale_removed = 0
                                     for package_name in cleanup_packages:

--- a/Palladium/Services/Python/palladium_ytdlp/packages.py
+++ b/Palladium/Services/Python/palladium_ytdlp/packages.py
@@ -366,7 +366,7 @@ def parse_package_source(source_json=None):
     source["mode"] = mode
     source["custom_specs"] = specs
     source["allow_prereleases"] = mode == "nightly"
-    source["skip_webkit_patch"] = mode == "custom"
+    source["skip_webkit_patch"] = mode == "custom" or bool(parsed.get("disable_webkit_jsi_patch"))
     return source
 
 

--- a/Palladium/Views/ContentView+Packages.swift
+++ b/Palladium/Views/ContentView+Packages.swift
@@ -106,6 +106,10 @@ extension ContentView {
             if let availableVersions = outcome.availableVersions {
                 self.availablePackageVersions = availableVersions
             }
+            if outcome.restartRequired {
+                alertMessage = String(localized: "settings.advanced.restart_required")
+                showAlert = true
+            }
             self.hasLoadedPackageStatus = true
             Self.logger.info("package flow finished with status: \(outcome.statusText, privacy: .public)")
 

--- a/Palladium/Views/ContentView+Packages.swift
+++ b/Palladium/Views/ContentView+Packages.swift
@@ -164,7 +164,8 @@ extension ContentView {
         let specs = customPackageSpecs()
         let payload: [String: Any] = [
             "mode": packageSourceMode.rawValue,
-            "custom_specs": specs
+            "custom_specs": specs,
+            "disable_webkit_jsi_patch": disableWebKitJSIPatch
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: payload),
               let text = String(data: data, encoding: .utf8) else {

--- a/Palladium/Views/ContentView+Packages.swift
+++ b/Palladium/Views/ContentView+Packages.swift
@@ -25,7 +25,7 @@ extension ContentView {
         isAutomaticallyUpdatingPackages = isAutomaticUpdate
         syncIdleTimerDisabled()
         switch action {
-        case "update":
+        case "update", "reinstall":
             packageStatusText = "updating"
         case "index_versions":
             packageStatusText = "indexing"
@@ -134,6 +134,15 @@ extension ContentView {
             return
         }
         runPackageFlow(action: "update")
+    }
+
+    func reinstallPackages() {
+        if packageSourceMode == .custom && customPackageSpecs().isEmpty {
+            alertMessage = String(localized: "packages.source.custom_specs.empty")
+            showAlert = true
+            return
+        }
+        runPackageFlow(action: "reinstall")
     }
 
     func updatePackagesWithCustomVersions(_ ytDlpVersion: String?, _ webkitJSIVersion: String?, _ pipVersion: String?) {

--- a/Palladium/Views/ContentView+Preferences.swift
+++ b/Palladium/Views/ContentView+Preferences.swift
@@ -64,6 +64,7 @@ extension ContentView {
         defaults.set(autoUpdatePackagesOnLaunch, forKey: Self.autoUpdatePackagesOnLaunchDefaultsKey)
         defaults.set(packageSourceMode.rawValue, forKey: Self.packageSourceModeDefaultsKey)
         defaults.set(customPackageSpecsText, forKey: Self.customPackageSpecsDefaultsKey)
+        defaults.set(disableWebKitJSIPatch, forKey: Self.disableWebKitJSIPatchDefaultsKey)
     }
 
     static func loadSelectedPreset(rememberSelection: Bool) -> DownloadPreset {
@@ -343,5 +344,9 @@ extension ContentView {
             return PackageSourceDefaults.customSpecs
         }
         return value
+    }
+
+    static func loadDisableWebKitJSIPatch() -> Bool {
+        UserDefaults.standard.bool(forKey: disableWebKitJSIPatchDefaultsKey)
     }
 }

--- a/Palladium/Views/ContentView.swift
+++ b/Palladium/Views/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
     static let autoUpdatePackagesOnLaunchDefaultsKey = "palladium.autoUpdatePackagesOnLaunch"
     static let packageSourceModeDefaultsKey = "palladium.packageSourceMode"
     static let customPackageSpecsDefaultsKey = "palladium.customPackageSpecs"
+    static let disableWebKitJSIPatchDefaultsKey = "palladium.disableWebKitJSIPatch"
     static let defaultLinkHistoryLimit = 10
     static let maxLinkHistoryLimit = 50
 
@@ -129,6 +130,7 @@ struct ContentView: View {
     @State var autoUpdatePackagesOnLaunch: Bool
     @State var packageSourceMode: PackageSourceMode
     @State var customPackageSpecsText: String
+    @State var disableWebKitJSIPatch: Bool
     @State var storageSummary: StorageManagementSummary = .empty
     @StateObject var consoleLogStore: ConsoleLogStore
     @State var completedDownloadResult: CompletedDownloadResult?
@@ -201,6 +203,7 @@ struct ContentView: View {
         _autoUpdatePackagesOnLaunch = State(initialValue: Self.loadAutoUpdatePackagesOnLaunch())
         _packageSourceMode = State(initialValue: Self.loadPackageSourceMode())
         _customPackageSpecsText = State(initialValue: Self.loadCustomPackageSpecsText())
+        _disableWebKitJSIPatch = State(initialValue: Self.loadDisableWebKitJSIPatch())
         _consoleLogStore = StateObject(wrappedValue: ConsoleLogStore())
     }
 
@@ -276,6 +279,7 @@ struct ContentView: View {
                     storageSummary: storageSummary,
                     packageSourceMode: $packageSourceMode,
                     customPackageSpecsText: $customPackageSpecsText,
+                    disableWebKitJSIPatch: $disableWebKitJSIPatch,
                     packageStatusText: packageStatusText,
                     versionsText: versionsText,
                     updatesSummaryText: packageUpdatesSummaryText,
@@ -442,6 +446,9 @@ struct ContentView: View {
             persistPreferences()
         }
         .onChange(of: customPackageSpecsText, initial: false) {
+            persistPreferences()
+        }
+        .onChange(of: disableWebKitJSIPatch, initial: false) {
             persistPreferences()
         }
         .sheet(item: $sharePayload) { payload in

--- a/Palladium/Views/ContentView.swift
+++ b/Palladium/Views/ContentView.swift
@@ -292,6 +292,7 @@ struct ContentView: View {
                     onRefreshVersions: refreshPackageVersions,
                     onCancelPackages: cancelPackageFlow,
                     onUpdatePackages: updatePackages,
+                    onReinstallPackages: reinstallPackages,
                     onCustomUpdatePackages: updatePackagesWithCustomVersions,
                     onFetchPackageVersions: fetchPackageIndexVersions,
                     onOpenPackageManager: loadPackageStatusIfNeeded,

--- a/Palladium/Views/Tabs/Settings/AdvancedSettingsView.swift
+++ b/Palladium/Views/Tabs/Settings/AdvancedSettingsView.swift
@@ -3,17 +3,31 @@ import SwiftUI
 struct AdvancedSettingsView: View {
     @Binding var disableWebKitJSIPatch: Bool
     let isRunning: Bool
+    let onReinstallPackages: () -> Void
+
+    @State private var showReinstallPrompt = false
 
     var body: some View {
         Form {
             Section {
                 Toggle("settings.advanced.disable_webkit_jsi_patch", isOn: $disableWebKitJSIPatch)
                     .disabled(isRunning)
+                    .onChange(of: disableWebKitJSIPatch) {
+                        showReinstallPrompt = true
+                    }
             } footer: {
                 Text("settings.advanced.disable_webkit_jsi_patch.help")
             }
         }
         .navigationTitle("settings.advanced.title")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("settings.advanced.reinstall_prompt.title", isPresented: $showReinstallPrompt) {
+            Button("common.cancel", role: .cancel) {}
+            Button("settings.advanced.reinstall") {
+                onReinstallPackages()
+            }
+        } message: {
+            Text("settings.advanced.reinstall_prompt.message")
+        }
     }
 }

--- a/Palladium/Views/Tabs/Settings/AdvancedSettingsView.swift
+++ b/Palladium/Views/Tabs/Settings/AdvancedSettingsView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct AdvancedSettingsView: View {
+    @Binding var disableWebKitJSIPatch: Bool
+    let isRunning: Bool
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("settings.advanced.disable_webkit_jsi_patch", isOn: $disableWebKitJSIPatch)
+                    .disabled(isRunning)
+            } footer: {
+                Text("settings.advanced.disable_webkit_jsi_patch.help")
+            }
+        }
+        .navigationTitle("settings.advanced.title")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Palladium/Views/Tabs/SettingsTabView.swift
+++ b/Palladium/Views/Tabs/SettingsTabView.swift
@@ -62,6 +62,7 @@ struct SettingsTabView: View {
     let onRefreshVersions: () -> Void
     let onCancelPackages: () -> Void
     let onUpdatePackages: () -> Void
+    let onReinstallPackages: () -> Void
     let onCustomUpdatePackages: (_ ytDlpVersion: String?, _ webkitJSIVersion: String?, _ pipVersion: String?) -> Void
     let onFetchPackageVersions: () -> Void
     let onOpenPackageManager: () -> Void
@@ -269,7 +270,8 @@ struct SettingsTabView: View {
                 case .advanced:
                     AdvancedSettingsView(
                         disableWebKitJSIPatch: $disableWebKitJSIPatch,
-                        isRunning: isRunning || isPackageRunning
+                        isRunning: isRunning || isPackageRunning,
+                        onReinstallPackages: onReinstallPackages
                     )
                 case .about:
                     SettingsAboutView()

--- a/Palladium/Views/Tabs/SettingsTabView.swift
+++ b/Palladium/Views/Tabs/SettingsTabView.swift
@@ -17,6 +17,7 @@ struct SettingsTabView: View {
         case notifications
         case storage
         case packages
+        case advanced
         case about
     }
 
@@ -48,6 +49,7 @@ struct SettingsTabView: View {
     let storageSummary: StorageManagementSummary
     @Binding var packageSourceMode: PackageSourceMode
     @Binding var customPackageSpecsText: String
+    @Binding var disableWebKitJSIPatch: Bool
     let packageStatusText: String
     let versionsText: String
     let updatesSummaryText: String
@@ -113,6 +115,15 @@ struct SettingsTabView: View {
 
                     NavigationLink(value: SettingsRoute.packages) {
                         packagesSettingsRow()
+                    }
+
+                    NavigationLink(value: SettingsRoute.advanced) {
+                        settingsRow(
+                            title: String(localized: "settings.advanced.title"),
+                            subtitle: String(localized: "settings.advanced.subtitle"),
+                            icon: "gearshape.2.fill",
+                            color: .gray
+                        )
                     }
                 }
 
@@ -254,6 +265,11 @@ struct SettingsTabView: View {
                         onCustomUpdatePackages: onCustomUpdatePackages,
                         onFetchPackageVersions: onFetchPackageVersions,
                         onAppear: onOpenPackageManager
+                    )
+                case .advanced:
+                    AdvancedSettingsView(
+                        disableWebKitJSIPatch: $disableWebKitJSIPatch,
+                        isRunning: isRunning || isPackageRunning
                     )
                 case .about:
                     SettingsAboutView()

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -72,6 +72,7 @@ Palladium/
 | `Views/Tabs/ConsoleTabView.swift` | In-app log console. |
 | `Views/Tabs/SettingsTabView.swift` | Settings tab container and navigation. |
 | `Views/Tabs/Settings/AfterDownloadSettingsView.swift` | Post-download settings screen. |
+| `Views/Tabs/Settings/AdvancedSettingsView.swift` | Advanced runtime settings screen. |
 | `Views/Tabs/Settings/AppearanceSettingsView.swift` | Appearance settings screen. |
 | `Views/Tabs/Settings/CookiesSettingsView.swift` | Cookie settings screen. |
 | `Views/Tabs/Settings/DownloadArgumentsSettingsView.swift` | Custom yt-dlp argument settings screen. |

--- a/scripts/test_package_source_modes.py
+++ b/scripts/test_package_source_modes.py
@@ -73,6 +73,14 @@ class PackageSourceModeTests(unittest.TestCase):
         self.assertTrue(custom_source["skip_webkit_patch"])
         self.assertFalse(stable_source["skip_webkit_patch"])
 
+    def test_explicit_setting_skips_webkit_patch(self):
+        source = parse_package_source(json.dumps({
+            "mode": "stable",
+            "disable_webkit_jsi_patch": True,
+        }))
+
+        self.assertTrue(source["skip_webkit_patch"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_package_source_modes.py
+++ b/scripts/test_package_source_modes.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import sys
+import types
 import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -11,6 +12,7 @@ from palladium_ytdlp.packages import (  # noqa: E402
     build_pip_install_args,
     parse_package_source,
 )
+from palladium_ytdlp.entrypoints import invalidate_runtime_package_modules  # noqa: E402
 
 
 class PackageSourceModeTests(unittest.TestCase):
@@ -80,6 +82,24 @@ class PackageSourceModeTests(unittest.TestCase):
         }))
 
         self.assertTrue(source["skip_webkit_patch"])
+
+    def test_runtime_package_module_cache_is_invalidated(self):
+        module_names = ("yt_dlp", "yt_dlp.extractor", "yt_dlp_plugins.webkit_jsi")
+        originals = {name: sys.modules.get(name) for name in module_names}
+        try:
+            for name in module_names:
+                sys.modules[name] = types.ModuleType(name)
+
+            invalidate_runtime_package_modules()
+
+            for name in module_names:
+                self.assertNotIn(name, sys.modules)
+        finally:
+            for name, module in originals.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
 
 
 if __name__ == "__main__":

--- a/scripts/test_package_source_modes.py
+++ b/scripts/test_package_source_modes.py
@@ -84,16 +84,36 @@ class PackageSourceModeTests(unittest.TestCase):
         self.assertTrue(source["skip_webkit_patch"])
 
     def test_runtime_package_module_cache_is_invalidated(self):
-        module_names = ("yt_dlp", "yt_dlp.extractor", "yt_dlp_plugins.webkit_jsi")
+        module_names = ("yt_dlp", "yt_dlp.extractor")
         originals = {name: sys.modules.get(name) for name in module_names}
         try:
             for name in module_names:
                 sys.modules[name] = types.ModuleType(name)
 
-            invalidate_runtime_package_modules()
+            restart_required = invalidate_runtime_package_modules()
 
             for name in module_names:
                 self.assertNotIn(name, sys.modules)
+            self.assertFalse(restart_required)
+        finally:
+            for name, module in originals.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+    def test_loaded_webkit_jsi_runtime_requires_restart(self):
+        module_names = ("yt_dlp", "yt_dlp_plugins.webkit_jsi")
+        originals = {name: sys.modules.get(name) for name in module_names}
+        try:
+            for name in module_names:
+                sys.modules[name] = types.ModuleType(name)
+
+            restart_required = invalidate_runtime_package_modules()
+
+            self.assertTrue(restart_required)
+            for name in module_names:
+                self.assertIn(name, sys.modules)
         finally:
             for name, module in originals.items():
                 if module is None:


### PR DESCRIPTION
Adds a new Advanced settings screen with a toggle to disable WebkitJSI runtime patch, with automatic package reinstall, prompt to restart app if needed for changes to take effect
